### PR TITLE
Update widgets.py SRS identifiers to conform with Django 1.7

### DIFF
--- a/floppyforms/gis/widgets.py
+++ b/floppyforms/gis/widgets.py
@@ -147,7 +147,7 @@ class BaseMetacartaWidget(BaseGeometryWidget):
 
 class BaseOsmWidget(BaseGeometryWidget):
     """An OpenStreetMap base widget"""
-    map_srid = 900913
+    map_srid = 3857
     template_name = 'floppyforms/gis/osm.html'
 
     class Media:
@@ -160,7 +160,7 @@ class BaseOsmWidget(BaseGeometryWidget):
 
 class BaseGMapWidget(BaseGeometryWidget):
     """A Google Maps base widget"""
-    map_srid = 900913
+    map_srid = 3857
     template_name = 'floppyforms/gis/google.html'
 
     class Media:


### PR DESCRIPTION
Remove deprecated 900913 SRID to conform with latest version of GDAL and Django 1.7

Related django ticket: https://code.djangoproject.com/ticket/22456