### PR TITLE
Adding a `make_floppy` utility method

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -144,3 +144,18 @@ field and a ``floppyforms.URLField`` for ``Profile.url``.
     Please make sure to test your code if your modelforms work still as
     expected with the new behaviour. The old version's behaviour will be
     removed completely with django-floppyforms 1.3.
+
+
+Dynamic Creation
+````````````````
+
+Sometimes making a new form class isn't practical, and instead you want to modify
+an existing form from another module. For this, a utility method, ``make_floppy``
+is provided
+
+.. code-block:: python
+
+    from my_module.forms import MyForm
+    from floppyforms.utils import make_floppy
+
+    MyFloppyForm = make_floppy(MyForm)

--- a/floppyforms/__future__/models.py
+++ b/floppyforms/__future__/models.py
@@ -21,7 +21,7 @@ __all__ = (
     'ModelForm', 'BaseModelForm', 'model_to_dict', 'fields_for_model',
     'save_instance', 'ModelChoiceField', 'ModelMultipleChoiceField',
     'BaseModelFormSet', 'modelformset_factory', 'BaseInlineFormSet',
-    'inlineformset_factory',
+    'inlineformset_factory', 'ModelFormMetaclass'
 )
 
 

--- a/floppyforms/utils.py
+++ b/floppyforms/utils.py
@@ -11,8 +11,10 @@ import warnings
 
 __all__ = ('make_floppy',)
 
+
 class TestForm(FloppyForm):
     pass
+
 
 def make_floppy(form_class):
 
@@ -36,8 +38,9 @@ def make_floppy(form_class):
                 form_class, OldFloppyModelForm), {})
         else:
             new_form_class = type(form_class.__name__, (
-                six.with_metaclass(ModelFormMetaclass,
-                form_class, FloppyModelForm),), {})
+                six.with_metaclass(
+                    ModelFormMetaclass,
+                    form_class, FloppyModelForm),), {})
 
     new_form_class.__module__ = form_class.__module__
 

--- a/floppyforms/utils.py
+++ b/floppyforms/utils.py
@@ -1,0 +1,44 @@
+from floppyforms.forms import Form as FloppyForm
+from floppyforms.__future__.models import (ModelFormMetaclass,
+                                           ModelForm as FloppyModelForm)
+from floppyforms.models import ModelForm as OldFloppyModelForm
+
+from django.forms import Form as DjangoForm, ModelForm as DjangoModelForm
+from django.utils import six
+import django
+
+import warnings
+
+__all__ = ('make_floppy',)
+
+class TestForm(FloppyForm):
+    pass
+
+def make_floppy(form_class):
+
+    form_instance = form_class()
+    if (
+        isinstance(form_instance, FloppyForm) or
+        isinstance(form_instance, FloppyModelForm)
+    ):
+        warnings.warn(
+            "Attempting to reclassify an existing Floppyform as a Floppyform",
+            RuntimeWarning)
+        return form_class
+
+    if isinstance(form_instance, DjangoForm):
+        new_form_class = type(form_class.__name__, (form_class, FloppyForm), {})
+
+    elif isinstance(form_instance, DjangoModelForm):
+
+        if django.VERSION < (1, 6):
+            new_form_class = type(form_class.__name__, (
+                form_class, OldFloppyModelForm), {})
+        else:
+            new_form_class = type(form_class.__name__, (
+                six.with_metaclass(ModelFormMetaclass,
+                form_class, FloppyModelForm),), {})
+
+    new_form_class.__module__ = form_class.__module__
+
+    return new_form_class

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -8,3 +8,4 @@ from .rendering import *
 from .templatetags import *
 from .widgets import *
 from .fields import *
+from .utils import *

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,47 @@
+from django.test import TestCase
+from django import forms
+
+from floppyforms.utils import make_floppy
+import floppyforms.__future__ as floppyforms
+
+from .models import Registration
+
+import warnings
+
+class MyForm(forms.Form):
+    name = forms.CharField()
+
+class MyModelForm(forms.ModelForm):
+    class Meta:
+        model = Registration
+
+class MyFloppyForm(floppyforms.Form):
+    name = floppyforms.CharField()
+
+
+class MakeFloppyTestCase(TestCase):
+
+    def test_make_basic_form_floppy(self):
+
+        NewClass = make_floppy(MyForm)
+
+        new_form = NewClass()
+
+        self.assertIsInstance(new_form, floppyforms.Form)
+
+    def test_make_model_form_floppy(self):
+
+        NewClass = make_floppy(MyModelForm)
+
+        new_form = NewClass()
+
+        self.assertIsInstance(new_form, floppyforms.ModelForm)
+
+    def test_try_make_existing_floppyform_floppy(self):
+
+        with warnings.catch_warnings(record=True) as w:
+
+            make_floppy(MyFloppyForm)
+
+            self.assertEqual(len(w), 1)
+            self.assertIsInstance(w[-1].category(), RuntimeWarning)


### PR DESCRIPTION
When you are using Form classes which have already been created in an external app, sometimes it's not practical or desirable to create entirely new Floppyform classes which mimic the field structure. I've created a simple utility method, `make_floppy`, which should allow you to take advantage of Floppyforms on existing Forms, without having to create new classes.