### PR TITLE
Adding a `make_floppy` utility method

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -144,3 +144,18 @@ field and a ``floppyforms.URLField`` for ``Profile.url``.
     Please make sure to test your code if your modelforms work still as
     expected with the new behaviour. The old version's behaviour will be
     removed completely with django-floppyforms 1.3.
+
+
+Dynamic Creation
+````````````````
+
+Sometimes making a new form class isn't practical, and instead you want to modify
+an existing form from another module. For this, a utility method, ``make_floppy``
+is provided
+
+.. code-block:: python
+
+    from my_module.forms import MyForm
+    from floppyforms.utils import make_floppy
+
+    MyFloppyForm = make_floppy(MyForm)

--- a/floppyforms/__future__/models.py
+++ b/floppyforms/__future__/models.py
@@ -21,7 +21,7 @@ __all__ = (
     'ModelForm', 'BaseModelForm', 'model_to_dict', 'fields_for_model',
     'save_instance', 'ModelChoiceField', 'ModelMultipleChoiceField',
     'BaseModelFormSet', 'modelformset_factory', 'BaseInlineFormSet',
-    'inlineformset_factory',
+    'inlineformset_factory', 'ModelFormMetaclass'
 )
 
 

--- a/floppyforms/utils.py
+++ b/floppyforms/utils.py
@@ -11,8 +11,10 @@ import warnings
 
 __all__ = ('make_floppy',)
 
+
 class TestForm(FloppyForm):
     pass
+
 
 def make_floppy(form_class):
 
@@ -36,8 +38,9 @@ def make_floppy(form_class):
                 form_class, OldFloppyModelForm), {})
         else:
             new_form_class = type(form_class.__name__, (
-                six.with_metaclass(ModelFormMetaclass,
-                form_class, FloppyModelForm),), {})
+                six.with_metaclass(
+                    ModelFormMetaclass,
+                    form_class, FloppyModelForm),), {})
 
     new_form_class.__module__ = form_class.__module__
 

--- a/floppyforms/utils.py
+++ b/floppyforms/utils.py
@@ -1,0 +1,44 @@
+from floppyforms.forms import Form as FloppyForm
+from floppyforms.__future__.models import (ModelFormMetaclass,
+                                           ModelForm as FloppyModelForm)
+from floppyforms.models import ModelForm as OldFloppyModelForm
+
+from django.forms import Form as DjangoForm, ModelForm as DjangoModelForm
+from django.utils import six
+import django
+
+import warnings
+
+__all__ = ('make_floppy',)
+
+class TestForm(FloppyForm):
+    pass
+
+def make_floppy(form_class):
+
+    form_instance = form_class()
+    if (
+        isinstance(form_instance, FloppyForm) or
+        isinstance(form_instance, FloppyModelForm)
+    ):
+        warnings.warn(
+            "Attempting to reclassify an existing Floppyform as a Floppyform",
+            RuntimeWarning)
+        return form_class
+
+    if isinstance(form_instance, DjangoForm):
+        new_form_class = type(form_class.__name__, (form_class, FloppyForm), {})
+
+    elif isinstance(form_instance, DjangoModelForm):
+
+        if django.VERSION < (1, 6):
+            new_form_class = type(form_class.__name__, (
+                form_class, OldFloppyModelForm), {})
+        else:
+            new_form_class = type(form_class.__name__, (
+                six.with_metaclass(ModelFormMetaclass,
+                form_class, FloppyModelForm),), {})
+
+    new_form_class.__module__ = form_class.__module__
+
+    return new_form_class

--- a/floppyforms/utils.py
+++ b/floppyforms/utils.py
@@ -2,12 +2,21 @@ from floppyforms.forms import Form as FloppyForm
 from floppyforms.__future__.models import (ModelFormMetaclass,
                                            ModelForm as FloppyModelForm)
 from floppyforms.models import ModelForm as OldFloppyModelForm
+import floppyforms.fields as ff_fields
+import floppyforms.widgets as ff_widgets
 
 from django.forms import Form as DjangoForm, ModelForm as DjangoModelForm
 from django.utils import six
 import django
 
+try:
+    from collections import OrderedDict
+except ImportError:
+    # Python 2.6
+    from django.utils.datastructures import SortedDict as OrderedDict
+
 import warnings
+import inspect
 
 __all__ = ('make_floppy',)
 
@@ -16,32 +25,184 @@ class TestForm(FloppyForm):
     pass
 
 
+def _get_class_args(klass):
+    """
+    Returns a list of arguments and dict of keyword arguments which can be
+    passed to klass when on instantiation
+    """
+
+    klass_args = []
+    klass_kwargs = {}
+
+    # Run through the inheritance chain of the class, gathering args and
+    # kwargs which are defined on each method. We only use the args
+    # signature of the most top level class (which should be the class itself)
+    klasses = inspect.getmro(klass)
+    for kls in reversed(klasses):  # reverse order to use the most top level
+        if (
+            not inspect.isfunction(kls.__init__) and  # python 3
+            not inspect.ismethod(kls.__init__)  # python 2
+        ):
+            continue
+
+        # Get the ArgSpec of initialization method
+        spec = inspect.getargspec(kls.__init__)
+        arg_names = spec[0]
+
+        # remove "self"
+        if arg_names:
+            arg_names.pop(0)
+
+        if spec.defaults:  # has kwargs
+            # kwarg names in arg_names are the last N values,
+            # where N is the lenght of defaults
+            start_index = len(arg_names) - len(spec.defaults)
+
+            current_index = 0
+            for kwarg in arg_names[start_index:]:
+                # build a kwarg signature based on the defaults, in order
+                klass_kwargs[kwarg] = spec.defaults[current_index]
+                current_index += 1
+
+            # the remaining arg names are positional args
+            kls_args = arg_names[:start_index]
+        else:
+            # no kwargs, they're all positional args
+            kls_args = arg_names
+
+        # use the positional args from the primary class
+        if kls is klass:
+            klass_args = kls_args
+
+    return klass_args, klass_kwargs
+
+
+def _get_calling_args(instance):
+    """
+    Returns a list of args and dict of keyword args which would be passed to
+    instance when creating it
+    """
+
+    calling_args = []
+    calling_kwargs = {}
+    klass = instance.__class__
+    klass_args, klass_kwargs = _get_class_args(klass)
+
+    # Positional args are tricky. We hope they're assigned as properties
+    # with the same name, and if so, use that value
+    for arg_name in klass_args:
+        calling_args.append(getattr(instance, arg_name, None))
+
+    # Keyword args likewise are assumed to be properties of the instance
+    # using the keyword value
+    for key, val in six.iteritems(instance.__dict__):
+        if key in klass_kwargs.keys():
+            calling_kwargs[key] = val
+
+    return calling_args, calling_kwargs
+
+
 def make_floppy(form_class):
 
-    form_instance = form_class()
-    if (
-        isinstance(form_instance, FloppyForm) or
-        isinstance(form_instance, FloppyModelForm)
-    ):
+    if not inspect.isclass(form_class):
+        raise TypeError('"make_floppy" should receive a class, not an instance')
+
+    if not issubclass(form_class, (DjangoForm, DjangoModelForm)):
+        raise TypeError('"make_floppy" only works on Forms and ModelForms')
+
+    if (issubclass(form_class, (FloppyForm, FloppyModelForm))):
         warnings.warn(
-            "Attempting to reclassify an existing Floppyform as a Floppyform",
+            """Attempting to reclassify an existing\
+               Floppyform class as a Floppyform""",
             RuntimeWarning)
         return form_class
 
-    if isinstance(form_instance, DjangoForm):
-        new_form_class = type(form_class.__name__, (form_class, FloppyForm), {})
-
-    elif isinstance(form_instance, DjangoModelForm):
-
-        if django.VERSION < (1, 6):
-            new_form_class = type(form_class.__name__, (
-                form_class, OldFloppyModelForm), {})
+    # Depending on which type of form this is, we create a new inheritance
+    # chain, which preserves the current chain and includes Floppyforms,
+    # so isinstance and issubclass will pass on new class
+    if django.VERSION >= (1, 6) and issubclass(form_class,
+                                               DjangoModelForm):
+        # complying with the __future__ functionality
+        class_list = (six.with_metaclass(ModelFormMetaclass,
+                                         form_class, FloppyModelForm),)
+    else:
+        if issubclass(form_class, DjangoModelForm):
+            class_list = (form_class, OldFloppyModelForm)
         else:
-            new_form_class = type(form_class.__name__, (
-                six.with_metaclass(
-                    ModelFormMetaclass,
-                    form_class, FloppyModelForm),), {})
+            class_list = (form_class, FloppyForm)
 
+    # create the new class
+    new_form_class = type(form_class.__name__, class_list, {})
+
+    # preserve the module location
     new_form_class.__module__ = form_class.__module__
+
+    # We also need to map the fields over, converting them to Floppyforms
+    # fields when possible. Custom fields will need to be converted in
+    # implementations
+
+    # In ModelForms, we only care about the declared fields
+    if issubclass(new_form_class, DjangoModelForm):
+        existing_fields = new_form_class.declared_fields
+    else:
+        # Regular Forms, we use all fields
+        existing_fields = new_form_class.base_fields
+
+    if existing_fields:
+        floppy_fields = []
+
+        # Go through all the fields and swap in their Floppyforms equivalent
+        for name, field in six.iteritems(form_class.base_fields):
+            if hasattr(ff_fields, field.__class__.__name__):
+                new_field_class = getattr(ff_fields,
+                                          field.__class__.__name__)
+            else:
+                new_field_class = None
+                warnings.warn("Cannot make custom field {field} floppy".format(
+                    field=field.__class__.__name__
+                ), RuntimeWarning)
+            calling_args, calling_kwargs = _get_calling_args(field)
+
+            # If the field was created with a specifically defined widget,
+            # try and swap this with the Floppyforms equivalent as well.
+            # Like fields, custom widgets will need to be updated by implementors
+            widget = calling_kwargs.pop('widget', None)
+            if widget:
+                if hasattr(ff_widgets, widget.__class__.__name__):
+                    new_widget_class = getattr(ff_widgets,
+                                               widget.__class__.__name__)
+                    w_calling_args, w_calling_kwargs = _get_calling_args(widget)
+
+                    new_widget = new_widget_class(*w_calling_args,
+                                                  **w_calling_kwargs)
+                    # If we updated the field, update the widget on that field
+                    if new_field_class:
+                        calling_kwargs['widget'] = new_widget
+                    else:
+                        # Just update the widget on the existing field
+                        field.widget = widget
+                else:
+                    warnings.warn("Cannot make custom widget {widget} floppy".format(
+                        widget=widget.__class__.__name__
+                    ), RuntimeWarning)
+                    # A new field preserves the same widget in this case
+                    if new_field_class:
+                        calling_kwargs['widget'] = widget
+
+            # Create the new field if we can
+            if new_field_class:
+                new_field = new_field_class(*calling_args,
+                                            **calling_kwargs)
+            else:
+                # Reuse the old field if we couldn't update it
+                new_field = field
+            floppy_fields.append((name, new_field))
+
+        new_fields = OrderedDict(floppy_fields)
+
+        if issubclass(new_form_class, DjangoModelForm):
+            new_form_class.declared_fields = new_fields
+        else:
+            new_form_class.base_fields = new_fields
 
     return new_form_class

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -8,3 +8,4 @@ from .rendering import *
 from .templatetags import *
 from .widgets import *
 from .fields import *
+from .utils import *

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -8,15 +8,42 @@ from .models import Registration
 
 import warnings
 
+
 class MyForm(forms.Form):
     name = forms.CharField()
+
 
 class MyModelForm(forms.ModelForm):
     class Meta:
         model = Registration
 
+
 class MyFloppyForm(floppyforms.Form):
     name = floppyforms.CharField()
+
+
+class MyRegexForm(forms.Form):
+    name = forms.RegexField(r'[a-zA-Z]')
+
+
+class MyField(forms.CharField):
+    pass
+
+
+class MyCustomFieldForm(forms.Form):
+    name = MyField()
+
+
+class MyWidget(forms.TextInput):
+    pass
+
+
+class MyCustomWidgetForm(forms.Form):
+    name = forms.CharField(widget=MyWidget())
+
+
+class OtherClass(object):
+    pass
 
 
 class MakeFloppyTestCase(TestCase):
@@ -24,6 +51,14 @@ class MakeFloppyTestCase(TestCase):
     def test_make_basic_form_floppy(self):
 
         NewClass = make_floppy(MyForm)
+
+        new_form = NewClass()
+
+        self.assertIsInstance(new_form, floppyforms.Form)
+
+    def test_make_form_with_arg_floppy(self):
+
+        NewClass = make_floppy(MyRegexForm)
 
         new_form = NewClass()
 
@@ -45,3 +80,37 @@ class MakeFloppyTestCase(TestCase):
 
             self.assertEqual(len(w), 1)
             self.assertIsInstance(w[-1].category(), RuntimeWarning)
+
+    def test_try_to_make_custom_field_floppy(self):
+
+        with warnings.catch_warnings(record=True) as w:
+
+            NewClass = make_floppy(MyCustomFieldForm)
+
+            self.assertEqual(len(w), 1)
+            self.assertIsInstance(w[-1].category(), RuntimeWarning)
+            self.assertIs(NewClass.base_fields['name'],
+                          MyCustomFieldForm.base_fields['name'])
+
+    def test_try_to_make_custom_widget_floppy(self):
+
+        with warnings.catch_warnings(record=True) as w:
+
+            NewClass = make_floppy(MyCustomWidgetForm)
+
+            self.assertEqual(len(w), 1)
+            self.assertIsInstance(w[-1].category(), RuntimeWarning)
+            self.assertIs(NewClass.base_fields['name'].widget,
+                          MyCustomWidgetForm.base_fields['name'].widget)
+
+    def test_try_to_make_instance_floppy(self):
+
+        form = MyForm()
+
+        with self.assertRaises(TypeError):
+            make_floppy(form)
+
+    def test_try_to_make_non_form_floppy(self):
+
+        with self.assertRaises(TypeError):
+            make_floppy(OtherClass)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,47 @@
+from django.test import TestCase
+from django import forms
+
+from floppyforms.utils import make_floppy
+import floppyforms.__future__ as floppyforms
+
+from .models import Registration
+
+import warnings
+
+class MyForm(forms.Form):
+    name = forms.CharField()
+
+class MyModelForm(forms.ModelForm):
+    class Meta:
+        model = Registration
+
+class MyFloppyForm(floppyforms.Form):
+    name = floppyforms.CharField()
+
+
+class MakeFloppyTestCase(TestCase):
+
+    def test_make_basic_form_floppy(self):
+
+        NewClass = make_floppy(MyForm)
+
+        new_form = NewClass()
+
+        self.assertIsInstance(new_form, floppyforms.Form)
+
+    def test_make_model_form_floppy(self):
+
+        NewClass = make_floppy(MyModelForm)
+
+        new_form = NewClass()
+
+        self.assertIsInstance(new_form, floppyforms.ModelForm)
+
+    def test_try_make_existing_floppyform_floppy(self):
+
+        with warnings.catch_warnings(record=True) as w:
+
+            make_floppy(MyFloppyForm)
+
+            self.assertEqual(len(w), 1)
+            self.assertIsInstance(w[-1].category(), RuntimeWarning)


### PR DESCRIPTION
When you are using Form classes which have already been created in an external app, sometimes it's not practical or desirable to create entirely new Floppyform classes which mimic the field structure. I've created a simple utility method, make_floppy, which should allow you to take advantage of Floppyforms on existing Forms, without having to create new classes.

Updated version of #136 