### PR TITLE
Don't crash in bdist_rpm with unicode issues.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ def find_version(*file_paths):
     version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
                               version_file, re.M)
     if version_match:
-        return version_match.group(1)
+        return str(version_match.group(1))
     raise RuntimeError("Unable to find version string.")
 
 


### PR DESCRIPTION
Presently, `python setup.py bdist_rpm` fails; the source of the problem is that distutils does no special encoding on the `version` kwarg to `distutils.core.setup`.

In the case that a `unicode` is specified for the `version` kwarg, the result is that it's concatenated with other (encoded) plain strs; the concatenation results in an attempt to convert the plain string to Unicode by interpreting its contents as ASCII, which fails when non-ASCII data was included.

i.e. it's a case of this:

```python
>>> u'é'.encode('utf-8') + u'e'
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 0: ordinal not in range(128)
>>>
```