### PR TITLE
DatetimeWidget render bug fix

### DIFF
--- a/floppyforms/widgets.py
+++ b/floppyforms/widgets.py
@@ -641,7 +641,7 @@ class SelectDateWidget(forms.Widget):
             year_val, month_val, day_val = value.year, value.month, value.day
         except AttributeError:
             year_val = month_val = day_val = None
-            if isinstance(value, six.text_type):
+            if isinstance(value, six.string_types):
                 if settings.USE_L10N:
                     try:
                         input_format = formats.get_format(


### PR DESCRIPTION
In my config, I used `settings.USE_L10N`, set the language to `fr`.
When initialized from POST data, the widget seemed to be reset to default values.
That's because in Python 2.7, `value_from_datadict` returns a `str` object, while `render` looks for a `unicode` object (represented by `six.text_type`). So it simply ignores the date string input.
You can only ensure compatibility by using `six.string_types` instead (which can cater for `basestring` in 2.7 and `unicode` in 3.x)