### PR TITLE
Fix widgets rendering

### DIFF
--- a/floppyforms/widgets.py
+++ b/floppyforms/widgets.py
@@ -423,7 +423,7 @@ class CheckboxInput(Input, forms.CheckboxInput):
             return False
         value = data.get(name)
         values = {'true': True, 'false': False}
-        if isinstance(value, six.text_type):
+        if isinstance(value, six.string_types):
             value = values.get(value.lower(), value)
         return value
 
@@ -641,7 +641,7 @@ class SelectDateWidget(forms.Widget):
             year_val, month_val, day_val = value.year, value.month, value.day
         except AttributeError:
             year_val = month_val = day_val = None
-            if isinstance(value, six.text_type):
+            if isinstance(value, six.string_types):
                 if settings.USE_L10N:
                     try:
                         input_format = formats.get_format(


### PR DESCRIPTION
Some widgets only take into input `unicode` strings (when coming from POST data), whereas they can output `str` strings (in Python 2.7, `DatetimeWidget.data_from_value_dict` uses `datetime.datetime.strftime` does return a `str` (not `unicode`). This value is ignored in `DatetimeWidget.render` because it's not a `unicode` - and should not hae to)
So the functionality was broken only in Python 2.7.
Replaced `six.text_type` (`unicode` in 2.7 and `str` in 3.3)  with `six.string_types` (`basestring` in 2.7 and `str` in 3.3)