### PR TITLE
Update imports deprecated in Django 1.9

### DIFF
--- a/floppyforms/templatetags/floppyforms.py
+++ b/floppyforms/templatetags/floppyforms.py
@@ -2,7 +2,11 @@ from collections import defaultdict
 from contextlib import contextmanager
 
 from django.conf import settings
-from django.forms.util import ErrorList
+try:
+    from django.forms.utils import ErrorList
+except ImportError:
+    # Fall back to old module name for Django <= 1.5
+    from django.forms.util import ErrorList
 from django.template import (Library, Node, Variable,
                              TemplateSyntaxError, VariableDoesNotExist)
 from django.template.base import token_kwargs


### PR DESCRIPTION
Taking example from another import of the same kind, compatibility with Django <=1.5 is preserved.

The import in question is 
django.forms.util -> django.forms.utils
which raises
RemovedInDjango19Warning: The django.forms.util module has been renamed. Use django.forms.utils instead.

