### PR TITLE
DecimalField now uses min, max, and decimal places (step) to create numberinput widget

### DIFF
--- a/floppyforms/fields.py
+++ b/floppyforms/fields.py
@@ -1,4 +1,5 @@
 from django import forms
+import decimal
 
 from .widgets import (TextInput, HiddenInput, CheckboxInput, Select,
                       ClearableFileInput, SelectMultiple, DateInput,
@@ -120,7 +121,7 @@ class DecimalField(Field, forms.DecimalField):
         if self.max_value is not None:
             attrs['max'] = self.max_value
         if self.decimal_places is not None:
-            attrs['step'] = Decimal('0.1') ** self.decimal_places
+            attrs['step'] = decimal.Decimal('0.1') ** self.decimal_places
         return attrs
 
 

--- a/floppyforms/fields.py
+++ b/floppyforms/fields.py
@@ -112,6 +112,16 @@ class DecimalField(Field, forms.DecimalField):
     def __init__(self, *args, **kwargs):
         kwargs.setdefault('widget', NumberInput if not kwargs.get('localize') else self.widget)
         super(DecimalField, self).__init__(*args, **kwargs)
+        
+    def widget_attrs(self, widget):
+        attrs = super(DecimalField, self).widget_attrs(widget) or {}
+        if self.min_value is not None:
+            attrs['min'] = self.min_value
+        if self.max_value is not None:
+            attrs['max'] = self.max_value
+        if self.decimal_places is not None:
+            attrs['step'] = 1/(10^self.decimal_places)
+        return attrs
 
 
 class EmailField(Field, forms.EmailField):

--- a/floppyforms/fields.py
+++ b/floppyforms/fields.py
@@ -113,7 +113,7 @@ class DecimalField(Field, forms.DecimalField):
     def __init__(self, *args, **kwargs):
         kwargs.setdefault('widget', NumberInput if not kwargs.get('localize') else self.widget)
         super(DecimalField, self).__init__(*args, **kwargs)
-  
+
     def widget_attrs(self, widget):
         attrs = super(DecimalField, self).widget_attrs(widget) or {}
         if self.min_value is not None:

--- a/floppyforms/fields.py
+++ b/floppyforms/fields.py
@@ -113,7 +113,6 @@ class DecimalField(Field, forms.DecimalField):
     def __init__(self, *args, **kwargs):
         kwargs.setdefault('widget', NumberInput if not kwargs.get('localize') else self.widget)
         super(DecimalField, self).__init__(*args, **kwargs)
-    
     def widget_attrs(self, widget):
         attrs = super(DecimalField, self).widget_attrs(widget) or {}
         if self.min_value is not None:

--- a/floppyforms/fields.py
+++ b/floppyforms/fields.py
@@ -113,6 +113,7 @@ class DecimalField(Field, forms.DecimalField):
     def __init__(self, *args, **kwargs):
         kwargs.setdefault('widget', NumberInput if not kwargs.get('localize') else self.widget)
         super(DecimalField, self).__init__(*args, **kwargs)
+  
     def widget_attrs(self, widget):
         attrs = super(DecimalField, self).widget_attrs(widget) or {}
         if self.min_value is not None:

--- a/floppyforms/fields.py
+++ b/floppyforms/fields.py
@@ -113,7 +113,7 @@ class DecimalField(Field, forms.DecimalField):
     def __init__(self, *args, **kwargs):
         kwargs.setdefault('widget', NumberInput if not kwargs.get('localize') else self.widget)
         super(DecimalField, self).__init__(*args, **kwargs)
-        
+    
     def widget_attrs(self, widget):
         attrs = super(DecimalField, self).widget_attrs(widget) or {}
         if self.min_value is not None:

--- a/floppyforms/fields.py
+++ b/floppyforms/fields.py
@@ -120,7 +120,7 @@ class DecimalField(Field, forms.DecimalField):
         if self.max_value is not None:
             attrs['max'] = self.max_value
         if self.decimal_places is not None:
-            attrs['step'] = 1/(10^self.decimal_places)
+            attrs['step'] = Decimal('0.1') ** self.decimal_places
         return attrs
 
 

--- a/tests/fields.py
+++ b/tests/fields.py
@@ -68,7 +68,7 @@ class DecimalFieldTests(TestCase):
     def test_parse_decimal(self):
         decimal_field = forms.DecimalField(decimal_places=2)
         result = decimal_field.clean('1.5')
-        self.assertEqual(decimal.Decimal(1.5), result)
+        self.assertEqual(decimal.Decimal('1.5'), result)
         self.assertIsInstance(result, decimal.Decimal)
 
     def test_pass_values(self):

--- a/tests/fields.py
+++ b/tests/fields.py
@@ -81,15 +81,15 @@ class DecimalFieldTests(TestCase):
         self.assertHTMLEqual(rendered, """
         <p>
             <label for="id_num">Num:</label>
-            <input type="number" name="num" id="id_num" max="10.5" step=".01" required>
+            <input type="number" name="num" id="id_num" max="10.5" step="0.01" required>
         </p>
         <p>
             <label for="id_other">Other:</label>
-            <input type="number" name="other" id="id_other" step=".1" required>
+            <input type="number" name="other" id="id_other" step="0.1" required>
         </p>
         <p>
             <label for="id_third">Third:</label>
-            <input type="number" name="third" id="id_third" min="-10" max="15" step=".001" required>
+            <input type="number" name="third" id="id_third" min="-10" max="15" step="0.001" required>
         </p>""")
 
 

--- a/tests/fields.py
+++ b/tests/fields.py
@@ -1,4 +1,5 @@
 import django
+import decimal
 from datetime import datetime
 from django.test import TestCase
 
@@ -61,6 +62,34 @@ class IntegerFieldTests(TestCase):
         <p>
             <label for="id_third">Third:</label>
             <input type="number" name="third" id="id_third" min="10" max="150" required>
+        </p>""")
+        
+class DecimalFieldTests(TestCase):
+    def test_parse_decimal(self):
+        decimal_field = forms.DecimalField(decimal_places=2)
+        result = decimal_field.clean('1.5')
+        self.assertEqual(decimal.Decimal(1.5), result)
+        self.assertIsInstance(result, decimal.Decimal)
+
+    def test_pass_values(self):
+        class DecimalForm(forms.Form):
+            num = forms.DecimalField(decimal_places=2, max_value=10.5)
+            other = forms.DecimalField(decimal_places=1)
+            third = forms.DecimalField(decimal_places=3, min_value=-10, max_value=15)
+
+        rendered = DecimalForm().as_p()
+        self.assertHTMLEqual(rendered, """
+        <p>
+            <label for="id_num">Num:</label>
+            <input type="number" name="num" id="id_num" max="10.5" step=".01" required>
+        </p>
+        <p>
+            <label for="id_other">Other:</label>
+            <input type="number" name="other" id="id_other" step=".1" required>
+        </p>
+        <p>
+            <label for="id_third">Third:</label>
+            <input type="number" name="third" id="id_third" min="-10" max="15" step=".001" required>
         </p>""")
 
 


### PR DESCRIPTION
See issue #70. Just used the same code as integerfield for min and max, with the addition of attrs['step']=1/(10^self.decimal_places). Similarly, added tests to verify it works. 