### PR TITLE
don't localize tag attributes values

### DIFF
--- a/floppyforms/templates/floppyforms/attrs.html
+++ b/floppyforms/templates/floppyforms/attrs.html
@@ -7,4 +7,4 @@
     which is just ugly in the resulting HTML. The tests will fail if you do so
     by accident :)
 
-{% endcomment %}{% load floppyforms_internals %}{% for name, value in attrs.items %} {{ name }}{% if not value|istrue %}="{{ value }}"{% endif %}{% endfor %}
+{% endcomment %}{% load floppyforms_internals l10n %}{% for name, value in attrs.items %} {{ name }}{% if not value|istrue %}="{% localize off %}{{ value }}{% endlocalize %}"{% endif %}{% endfor %}

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -1,4 +1,5 @@
 import datetime
+import decimal
 import os
 import sys
 
@@ -1373,3 +1374,12 @@ class AttrsTemplateTests(TestCase):
         # disabled shouldn't have a value
         self.assertTrue(' disabled' in rendered)
         self.assertTrue(' disabled=' not in rendered)
+
+    def test_attrs_not_localized(self):
+
+        # We should got 0.01, not 0,01.
+        with override_settings(USE_L10N=True, LANGUAGE_CODE='fr-fr'):
+            rendered = self.render_attrs({'step': decimal.Decimal('0.01')})
+            self.assertTrue(rendered in [
+                ' step="0.01"',
+            ])


### PR DESCRIPTION
Hi,

Since latest commits, `DecimalField` (and `FloatField` I guess) have `min`, `max` and `step` properties. Step property use the `decimal_place` attribute.

However, attribute values are rendered with the template engine. And if settings ``USE_L10N=True``, any values would be localized by default.
As a consequence, with the French language enabled, we would got a HTML tag attribut `step=0,01`. With Chrome at least, this could be invalid and round the step to integer!

I think that we should do the same thing for any attributes: force them to don't be localized.

However, a special note should be throw to other users implementing their own ``attrs.html`` template because they may update it too (if using l10n and applying the default behaviour, which is to localize any values).

Thanks