### PR TITLE
Update widget.is_required value on field.required update

### DIFF
--- a/floppyforms/fields.py
+++ b/floppyforms/fields.py
@@ -26,6 +26,16 @@ class Field(forms.Field):
     widget = TextInput
     hidden_widget = HiddenInput
 
+    @property
+    def required(self):
+        return self.__required
+
+    @required.setter
+    def required(self, value):
+        self.__required = value
+        if getattr(self, 'widget', None) and not isinstance(self.widget, type):
+            self.widget.is_required = value
+
 
 class CharField(Field, forms.CharField):
     widget = TextInput

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -6,7 +6,7 @@ from django.test import TestCase
 import floppyforms.__future__ as forms
 
 from .compat import unittest
-from .models import ImageFieldModel
+from .models import ImageFieldModel, Registration
 
 
 skipIf = unittest.skipIf
@@ -16,6 +16,39 @@ class ImageFieldModelForm(forms.ModelForm):
     class Meta:
         model = ImageFieldModel
         fields = ('image_field',)
+
+
+@skipIf(django.VERSION < (1, 6), 'Only applies to Django >= 1.6')
+class RequiredFieldTest(TestCase):
+    def test_required_field(self):
+        class RegistrationForm(forms.ModelForm):
+            class Meta:
+                model = Registration
+                fields = ('age', )
+
+        rendered = RegistrationForm().as_p()
+        self.assertHTMLEqual(rendered, """
+        <p>
+            <label for="id_age">Age:</label>
+            <input type="number" name="age" id="id_age" required>
+        </p>""")
+
+    def test_not_required_field(self):
+        class RegistrationForm(forms.ModelForm):
+            class Meta:
+                model = Registration
+                fields = ('age', )
+
+            def __init__(self, *args, **kwargs):
+                super(RegistrationForm, self).__init__(*args, **kwargs)
+                self.fields['age'].required = False
+
+        rendered = RegistrationForm().as_p()
+        self.assertHTMLEqual(rendered, """
+        <p>
+            <label for="id_age">Age:</label>
+            <input type="number" name="age" id="id_age">
+        </p>""")
 
 
 class DateTimeFieldTests(TestCase):


### PR DESCRIPTION
I didn't found in documentation why `required` attr is still rendered when I change `field.required` to False.
So I looked into the code and found that I have to update `widget.is_required` too.
This change keeps `field.required` and `widget.is_required` in sync.
I'm not sure that this is a good solution for everyone and of course it will break others people projects but at least we can add information about `widget.is_required` to the documentation.